### PR TITLE
Fix crash/error when opening another webview after closing one during one application run

### DIFF
--- a/flutter_web_auth_2/lib/src/windows.dart
+++ b/flutter_web_auth_2/lib/src/windows.dart
@@ -46,6 +46,11 @@ class FlutterWebAuth2WindowsPlugin extends FlutterWebAuth2Platform {
       if (uri.scheme == callbackUrlScheme) {
         authenticated = true;
         webview?.close();
+        /**
+         * Not setting the webview to null will cause a crash if the 
+         * application tries to open another webview
+         */
+        webview = null;
         c.complete(url);
       }
     });

--- a/flutter_web_auth_2/lib/src/windows.dart
+++ b/flutter_web_auth_2/lib/src/windows.dart
@@ -45,19 +45,23 @@ class FlutterWebAuth2WindowsPlugin extends FlutterWebAuth2Platform {
       final uri = Uri.parse(url);
       if (uri.scheme == callbackUrlScheme) {
         authenticated = true;
-        c.complete(url);
         webview?.close();
+        c.complete(url);
       }
     });
     unawaited(
       webview!.onClose.whenComplete(
-        () => {
-          if (!authenticated)
-            {
-              c.completeError(
-                PlatformException(code: 'CANCELED', message: 'User canceled'),
-              ),
-            },
+        () {
+          /**
+           * Not setting the webview to null will cause a crash if the 
+           * application tries to open another webview
+           */
+          webview = null;
+          if (!authenticated) {
+            c.completeError(
+              PlatformException(code: 'CANCELED', message: 'User canceled'),
+            );
+          }
         },
       ),
     );


### PR DESCRIPTION
webview was not correctly reset to null which caused an issue when opening another webview during one application run. 